### PR TITLE
GDB-7072 Disable anonymous stats being sent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <version>2.0-SNAPSHOT</version>
 
     <properties>
-        <graphdb.version>10.0.0-M2-TR8</graphdb.version>
+        <graphdb.version>10.0.0</graphdb.version>
         <dependency.check.version>6.2.2</dependency.check.version>
     </properties>
 
@@ -34,6 +34,16 @@
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M3</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <graphdb.stats.default>disabled</graphdb.stats.default>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/test/java/com/ontotext/trree/plugin/example/TestExampleBasicPlugin.java
+++ b/src/test/java/com/ontotext/trree/plugin/example/TestExampleBasicPlugin.java
@@ -1,5 +1,7 @@
 package com.ontotext.trree.plugin.example;
 
+import com.ontotext.graphdb.Config;
+import com.ontotext.test.TemporaryLocalFolder;
 import com.ontotext.test.functional.base.SingleRepositoryFunctionalTest;
 import com.ontotext.test.utils.StandardUtils;
 import org.eclipse.rdf4j.model.Literal;
@@ -9,6 +11,9 @@ import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.config.RepositoryConfig;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -22,10 +27,25 @@ import static org.junit.Assert.*;
  * Tests the exampleBasic plugin.
  */
 public class TestExampleBasicPlugin extends SingleRepositoryFunctionalTest {
+
+    @ClassRule
+    public static TemporaryLocalFolder tmpFolder = new TemporaryLocalFolder();
     @Override
     protected RepositoryConfig createRepositoryConfiguration() {
         // Creates a repository configuration with the rdfsplus-optimized ruleset
         return StandardUtils.createOwlimSe("rdfsplus-optimized");
+    }
+
+    @BeforeClass
+    public static void setWorkDir() {
+        System.setProperty("graphdb.home.work", String.valueOf(tmpFolder.getRoot()));
+        Config.reset();
+    }
+
+    @AfterClass
+    public static void resetWorkDir() {
+        System.clearProperty("graphdb.home.work");
+        Config.reset();
     }
 
     @Test

--- a/src/test/java/com/ontotext/trree/plugin/example/TestExampleFunctionalPlugin.java
+++ b/src/test/java/com/ontotext/trree/plugin/example/TestExampleFunctionalPlugin.java
@@ -1,5 +1,7 @@
 package com.ontotext.trree.plugin.example;
 
+import com.ontotext.graphdb.Config;
+import com.ontotext.test.TemporaryLocalFolder;
 import com.ontotext.test.functional.base.SingleRepositoryFunctionalTest;
 import com.ontotext.test.utils.StandardUtils;
 import org.eclipse.rdf4j.query.TupleQueryResult;
@@ -8,8 +10,7 @@ import org.eclipse.rdf4j.repository.config.RepositoryConfig;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -23,10 +24,24 @@ import static org.junit.Assert.fail;
  * Tests the exampleFunctional plugin.
  */
 public class TestExampleFunctionalPlugin extends SingleRepositoryFunctionalTest {
+
+    @ClassRule
+    public static TemporaryLocalFolder tmpFolder = new TemporaryLocalFolder();
     @Override
     protected RepositoryConfig createRepositoryConfiguration() {
         // Creates a repository configuration with the rdfsplus-optimized ruleset
         return StandardUtils.createOwlimSe("rdfsplus-optimized");
+    }
+    @BeforeClass
+    public static void setWorkDir() {
+        System.setProperty("graphdb.home.work", String.valueOf(tmpFolder.getRoot()));
+        Config.reset();
+    }
+
+    @AfterClass
+    public static void resetWorkDir() {
+        System.clearProperty("graphdb.home.work");
+        Config.reset();
     }
 
     @Before

--- a/src/test/java/com/ontotext/trree/plugin/example/TestExamplePlugin.java
+++ b/src/test/java/com/ontotext/trree/plugin/example/TestExamplePlugin.java
@@ -1,5 +1,7 @@
 package com.ontotext.trree.plugin.example;
 
+import com.ontotext.graphdb.Config;
+import com.ontotext.test.TemporaryLocalFolder;
 import com.ontotext.test.functional.base.SingleRepositoryFunctionalTest;
 import com.ontotext.test.utils.StandardUtils;
 import org.eclipse.rdf4j.model.Literal;
@@ -9,6 +11,9 @@ import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.config.RepositoryConfig;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -17,10 +22,25 @@ import static org.junit.Assert.*;
  * Tests the example plugin.
  */
 public class TestExamplePlugin extends SingleRepositoryFunctionalTest {
+
+    @ClassRule
+    public static TemporaryLocalFolder tmpFolder = new TemporaryLocalFolder();
+
     @Override
     protected RepositoryConfig createRepositoryConfiguration() {
         // Creates a repository configuration with the rdfsplus-optimized ruleset
         return StandardUtils.createOwlimSe("rdfsplus-optimized");
+    }
+    @BeforeClass
+    public static void setWorkDir() {
+        System.setProperty("graphdb.home.work", String.valueOf(tmpFolder.getRoot()));
+        Config.reset();
+    }
+
+    @AfterClass
+    public static void resetWorkDir() {
+        System.clearProperty("graphdb.home.work");
+        Config.reset();
     }
 
     @Test


### PR DESCRIPTION
Change graphDB version to 10.0.0.
Add custom configuration for surefire plugin so we can use "<graphdb.stats.default>disabled</graphdb.stats.default>".
Add temporary home.work folder to all tests.